### PR TITLE
Add depth limit flags & flat-flags

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,18 +16,6 @@
             ]
         },
         {
-            "name": "Write markdown to stdout",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "program": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "args": [
-                "values.schema.json",
-                "-f markdown"
-            ]
-        },
-        {
             "name": "Write to file",
             "type": "go",
             "request": "launch",
@@ -38,6 +26,43 @@
                 "values.schema.json",
                 "-t ArgoCD Helm Values",
                 "-o rendered.adoc"
+            ]
+        },
+        {
+            "name": "Write to file (depth limit = 2)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "args": [
+                "-d=2",
+                "-o rendered.adoc",
+                "values.schema.json"
+            ]
+        },
+        {
+            "name": "Write to stdout (depth limit = 2)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "args": [
+                "-d=2",
+                "values.schema.json"
+            ]
+        },
+        {
+            "name": "Write markdown to stdout",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "args": [
+                "values.schema.json",
+                "-f markdown"
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,6 +66,20 @@
             ]
         },
         {
+            "name": "Write markdown to file  (depth limit = 2)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "args": [
+                "-d=2",
+                "values.schema.json",
+                "-o rendered.md",
+                "-f markdown"
+            ]
+        },
+        {
             "name": "Write markdown to file",
             "type": "go",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,19 @@
             ]
         },
         {
+            "name": "Write to file, dump securityContext",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "args": [
+                "--flat=containerSecurityContext,securityContext,resources,affinity,tolerations,nodeSelector",
+                "values.schema.json",
+                "-o rendered.adoc"
+            ]
+        },
+        {
             "name": "Write to file (depth limit = 2)",
             "type": "go",
             "request": "launch",
@@ -50,6 +63,18 @@
             "console": "integratedTerminal",
             "args": [
                 "-d=2",
+                "values.schema.json"
+            ]
+        },
+        {
+            "name": "Write to stdout, dump securityContext",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "args": [
+                "--flat=securityContext",
                 "values.schema.json"
             ]
         },

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -48,7 +48,7 @@ func renderDoc(input, outFile, format, title string, depth int) error {
 	output += r.Header(title, 0)
 	output += r.TableHeader()
 	for _, sch := range schema.Properties {
-		output += r.PropertyRow("", *sch)
+		output += r.PropertyRow("", *sch, depth == 1)
 		gatherObjects("", sch)
 	}
 	output += r.TableFooter()
@@ -73,8 +73,9 @@ func renderDoc(input, outFile, format, title string, depth int) error {
 			sort.Strings(propertyKeys)
 
 			for _, s := range propertyKeys {
-				output += r.PropertyRow(key, *objects[key].Properties[s])
+				output += r.PropertyRow(key, *objects[key].Properties[s], strings.Count(key, ">") == depth)
 			}
+
 			output += r.TableFooter()
 			output += "\n"
 		}

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -28,7 +28,7 @@ func validateInputFile(inputFile string) error {
 	return nil
 }
 
-func renderDoc(input, outFile, format, title string) error {
+func renderDoc(input, outFile, format, title string, depth int) error {
 	c := jsonschema.NewCompiler()
 	schema, err := c.Compile(input)
 	if err != nil {
@@ -63,19 +63,21 @@ func renderDoc(input, outFile, format, title string) error {
 	sort.Strings(objectsKeys)
 
 	for _, key := range objectsKeys {
-		output += r.PropertyHeader(key, strings.Count(key, ">")+1)
-		output += r.TableHeader()
-		propertyKeys := make([]string, 0, len(objects[key].Properties))
-		for k := range objects[key].Properties {
-			propertyKeys = append(propertyKeys, k)
-		}
-		sort.Strings(propertyKeys)
+		if depth == 0 || strings.Count(key, ">") <= depth {
+			output += r.PropertyHeader(key, strings.Count(key, ">")+1)
+			output += r.TableHeader()
+			propertyKeys := make([]string, 0, len(objects[key].Properties))
+			for k := range objects[key].Properties {
+				propertyKeys = append(propertyKeys, k)
+			}
+			sort.Strings(propertyKeys)
 
-		for _, s := range propertyKeys {
-			output += r.PropertyRow(key, *objects[key].Properties[s])
+			for _, s := range propertyKeys {
+				output += r.PropertyRow(key, *objects[key].Properties[s])
+			}
+			output += r.TableFooter()
+			output += "\n"
 		}
-		output += r.TableFooter()
-		output += "\n"
 	}
 
 	if outFile != "" {

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -28,7 +29,7 @@ func validateInputFile(inputFile string) error {
 	return nil
 }
 
-func renderDoc(input, outFile, format, title string, depth int) error {
+func renderDoc(input, outFile, format, title string, depth int, flatObjects []string) error {
 	c := jsonschema.NewCompiler()
 	schema, err := c.Compile(input)
 	if err != nil {
@@ -49,7 +50,7 @@ func renderDoc(input, outFile, format, title string, depth int) error {
 	output += r.TableHeader()
 	for _, sch := range schema.Properties {
 		output += r.PropertyRow("", *sch, depth == 1)
-		gatherObjects("", sch)
+		gatherObjects("", sch, flatObjects)
 	}
 	output += r.TableFooter()
 	output += "\n"
@@ -63,9 +64,11 @@ func renderDoc(input, outFile, format, title string, depth int) error {
 	sort.Strings(objectsKeys)
 
 	for _, key := range objectsKeys {
+
 		if depth == 0 || strings.Count(key, ">") <= depth {
 			output += r.PropertyHeader(key, strings.Count(key, ">")+1)
 			output += r.TableHeader()
+
 			propertyKeys := make([]string, 0, len(objects[key].Properties))
 			for k := range objects[key].Properties {
 				propertyKeys = append(propertyKeys, k)
@@ -73,7 +76,15 @@ func renderDoc(input, outFile, format, title string, depth int) error {
 			sort.Strings(propertyKeys)
 
 			for _, s := range propertyKeys {
-				output += r.PropertyRow(key, *objects[key].Properties[s], strings.Count(key, ">") == depth)
+
+				dumpValue := strings.Count(key, ">") == depth
+				if slices.Contains(flatObjects, s) {
+					dumpValue = true
+				} else if depth == 0 {
+					dumpValue = false
+				}
+
+				output += r.PropertyRow(key, *objects[key].Properties[s], dumpValue)
 			}
 
 			output += r.TableFooter()
@@ -112,8 +123,13 @@ func writeToFile(outFile, output string) error {
 	return nil
 }
 
-func gatherObjects(parentTitle string, schema *jsonschema.Schema) {
+func gatherObjects(parentTitle string, schema *jsonschema.Schema, flatObjects []string) {
 	name := schema.Title
+
+	if slices.Contains(flatObjects, name) {
+		return
+	}
+
 	if parentTitle != "" {
 		name = strings.Join([]string{parentTitle, schema.Title}, " > ")
 	}
@@ -125,7 +141,7 @@ func gatherObjects(parentTitle string, schema *jsonschema.Schema) {
 
 		for _, sch := range schema.Properties {
 			if sch.Types.String() == "[object]" {
-				gatherObjects(name, sch)
+				gatherObjects(name, sch, flatObjects)
 			}
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,8 +71,9 @@ var rootCmd = &cobra.Command{
 		format := strings.Trim(cmd.Flag("format").Value.String(), " ")
 		title := strings.Trim(cmd.Flag("title").Value.String(), " ")
 		depth, _ := cmd.Flags().GetInt("depth")
+		flatObjects, _ := cmd.Flags().GetStringSlice("flat")
 
-		return renderDoc(inputFile, output, format, title, depth)
+		return renderDoc(inputFile, output, format, title, depth, flatObjects)
 	},
 }
 
@@ -93,4 +94,6 @@ func init() {
 	rootCmd.Flags().StringP("title", "t", "Root Schema", "Title of the document")
 
 	rootCmd.Flags().IntP("depth", "d", 0, "Depth of the schema to render")
+
+	rootCmd.Flags().StringSlice("flat", []string{}, "Properties to always dump to json, and not recurse into. For Helm schemas, recommended to use: 'securityContext,resources,affinity,tolerations,nodeSelector'")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,8 +70,9 @@ var rootCmd = &cobra.Command{
 		output := strings.Trim(cmd.Flag("output").Value.String(), " ")
 		format := strings.Trim(cmd.Flag("format").Value.String(), " ")
 		title := strings.Trim(cmd.Flag("title").Value.String(), " ")
+		depth, _ := cmd.Flags().GetInt("depth")
 
-		return renderDoc(inputFile, output, format, title)
+		return renderDoc(inputFile, output, format, title, depth)
 	},
 }
 
@@ -90,4 +91,6 @@ func init() {
 	rootCmd.Flags().StringP("format", "f", "asciidoc", "Output format (asciidoc, markdown)")
 
 	rootCmd.Flags().StringP("title", "t", "Root Schema", "Title of the document")
+
+	rootCmd.Flags().IntP("depth", "d", 0, "Depth of the schema to render")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,5 +95,5 @@ func init() {
 
 	rootCmd.Flags().IntP("depth", "d", 0, "Depth of the schema to render")
 
-	rootCmd.Flags().StringSlice("flat", []string{}, "Properties to always dump to json, and not recurse into. For Helm schemas, recommended to use: 'securityContext,resources,affinity,tolerations,nodeSelector'")
+	rootCmd.Flags().StringSlice("flat", []string{}, "Properties to always dump to json, and not recurse into, can be repeated multiple times, or comma separated. For Helm schemas, recommended to use: 'securityContext,resources,affinity,tolerations,nodeSelector'")
 }

--- a/pkg/markdown/templates.go
+++ b/pkg/markdown/templates.go
@@ -33,12 +33,12 @@ func (MarkdownRenderer) TableFooter() string {
 	return ""
 }
 
-func (MarkdownRenderer) PropertyRow(parent string, schema jsonschema.Schema, maxDepth bool) string {
+func (m MarkdownRenderer) PropertyRow(parent string, schema jsonschema.Schema, maxDepth bool) string {
 
 	description := strings.ReplaceAll(schema.Description, "\n", "<br>")
 
 	if schema.Types.String() != "[object]" {
-		return fmt.Sprintf("| %s | %s | %s | %s |\n", schema.Title, strings.Join(schema.Types.ToStrings(), ", "), renderer.GetValue(schema), description)
+		return fmt.Sprintf("| %s | %s | `%s` | %s |\n", schema.Title, strings.Join(schema.Types.ToStrings(), ", "), renderer.GetValue(schema), description)
 	}
 
 	id := strings.ToLower(schema.Title)
@@ -46,6 +46,24 @@ func (MarkdownRenderer) PropertyRow(parent string, schema jsonschema.Schema, max
 		id = strings.ToLower(strings.ReplaceAll(parent, " > ", "-")) + "-" + strings.ToLower(schema.Title)
 	}
 
+	if maxDepth {
+		return fmt.Sprintf("| %s | %s | %s | %s |\n", schema.Title, strings.Join(schema.Types.ToStrings(), ", "), m.dumpPropertiesToValue(schema.Properties), description)
+	}
+
 	return fmt.Sprintf("| [%s](#%s) | %s | %s | %s |\n", schema.Title, id, strings.Join(schema.Types.ToStrings(), ", "), "", description)
 
+}
+
+func (MarkdownRenderer) dumpPropertiesToValue(properties map[string]*jsonschema.Schema) string {
+
+	jsonString := renderer.DumpPropertiesToJson(properties)
+
+	formattedJson := strings.ReplaceAll(string(jsonString), " ", "&nbsp;")
+	formattedJson = strings.ReplaceAll(string(formattedJson), "\n", "<br>")
+
+	output := "<pre>"
+	output += formattedJson
+	output += "</pre>"
+
+	return output
 }

--- a/pkg/markdown/templates.go
+++ b/pkg/markdown/templates.go
@@ -33,7 +33,7 @@ func (MarkdownRenderer) TableFooter() string {
 	return ""
 }
 
-func (MarkdownRenderer) PropertyRow(parent string, schema jsonschema.Schema) string {
+func (MarkdownRenderer) PropertyRow(parent string, schema jsonschema.Schema, maxDepth bool) string {
 
 	description := strings.ReplaceAll(schema.Description, "\n", "<br>")
 

--- a/pkg/renderer/renderer.go
+++ b/pkg/renderer/renderer.go
@@ -12,7 +12,7 @@ type Renderer interface {
 	PropertyHeader(string, int) string
 	TableHeader() string
 	TableFooter() string
-	PropertyRow(string, jsonschema.Schema) string
+	PropertyRow(string, jsonschema.Schema, bool) string
 }
 
 func GetValue(schema jsonschema.Schema) string {
@@ -52,4 +52,26 @@ func GetValue(schema jsonschema.Schema) string {
 	}
 
 	return ""
+}
+
+func DumpPropertiesToJson(properties map[string]*jsonschema.Schema) string {
+
+	props := dumpPropertiesToMap(properties)
+
+	b, _ := json.MarshalIndent(props, "", " ")
+	return string(b)
+}
+
+func dumpPropertiesToMap(properties map[string]*jsonschema.Schema) map[string]interface{} {
+
+	props := map[string]interface{}{}
+	for k, v := range properties {
+		if v.Types.String() == "[object]" {
+			props[k] = dumpPropertiesToMap(v.Properties)
+		} else {
+			props[k] = v.Default
+		}
+	}
+
+	return props
 }


### PR DESCRIPTION
`depth` allows to set the maximum depth to nest objects. Objects at max depth will be dumped to json into a code block

`flat` objects matching those names, will be dumped to json, indepdently of the max depth